### PR TITLE
fix(android): WeChat package visibility for isInstalled on Android 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ You'll need to integrate the WeChat SDK into your iOS project. Add the WeChat SD
 
 ### Android
 
-Add the following to your `AndroidManifest.xml`:
+The plugin ships an `AndroidManifest.xml` with the Android 11+ package visibility query for WeChat (`com.tencent.mm`). That is required for `isInstalled()` / `isWXAppInstalled()` to work on Android 11 and newer. If you maintain a custom manifest merge setup, add:
+
+```xml
+<queries>
+  <package android:name="com.tencent.mm" />
+</queries>
+```
+
+Also add the WeChat callback activity to your app `AndroidManifest.xml`:
 
 ```xml
 <manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+      Android 11+ package visibility: required for isWXAppInstalled() / isInstalled().
+      Without this, the OS always reports WeChat as not installed.
+    -->
+    <queries>
+        <package android:name="com.tencent.mm" />
+    </queries>
+</manifest>

--- a/example-app/android/app/src/main/AndroidManifest.xml
+++ b/example-app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Android 11+ package visibility for WeChat (isInstalled) -->
+    <queries>
+        <package android:name="com.tencent.mm" />
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## What
- Ship plugin `AndroidManifest.xml` with `<queries>` for `com.tencent.mm`
- Document Android 11+ package visibility requirement
- Add the same query to the example app manifest

## Why
- Fixes https://github.com/Cap-go/capacitor-wechat/issues/40
- On Android 11+, `isWXAppInstalled()` / `isInstalled()` always returns false unless WeChat is declared under `<queries>`

## How
- Manifest merger from the plugin library injects the package visibility query into host apps
- README notes the requirement for custom merge setups

## Testing
- Confirmed manifest and docs changes locally
- `git` commit includes plugin + example-app + README

## Not Tested
- Physical Android 11+ / 16 device with WeChat installed (needs device + WeChat)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-wechat/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788691104&installation_model_id=430928&pr_number=41&repository=Cap-go%2Fcapacitor-wechat&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-wechat%2Fpull%2F41&signature=5a06eb48556994cc28c35fc5591a6c55b0240cc30e283e3c88315482953b98eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-wechat/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

