### PR TITLE
fix(ios): WeChat login auth code never returned (#39)

### DIFF
--- a/ios/Sources/CapacitorWechatPlugin/CapacitorWechat+Operations.swift
+++ b/ios/Sources/CapacitorWechatPlugin/CapacitorWechat+Operations.swift
@@ -44,7 +44,7 @@ extension CapacitorWechat {
         WXApi.isWXAppInstalled()
     }
 
-    func auth(scope: String, state: String?, presenter: UIViewController, completion: @escaping (Result<WechatAuthResponse, Error>) -> Void) throws {
+    func auth(scope: String, state: String?, presenter _: UIViewController, completion: @escaping (Result<WechatAuthResponse, Error>) -> Void) throws {
         try ensureConfigured()
         guard WXApi.isWXAppInstalled() else {
             throw WechatError.wechatNotInstalled
@@ -56,11 +56,13 @@ extension CapacitorWechat {
         }
         authCompletion = completion
 
+        // Use send(_:) when WeChat is installed. sendAuthReq(_:viewController:) is for
+        // devices without WeChat and can emit a spurious user-cancel while opening WeChat.
         DispatchQueue.main.async {
             let req = SendAuthReq()
             req.scope = scope
             req.state = state ?? UUID().uuidString
-            WXApi.sendAuthReq(req, viewController: presenter, delegate: self) { success in
+            WXApi.send(req) { success in
                 if !success {
                     self.consumeAuth(with: .failure(WechatError.requestFailed))
                 }
@@ -199,6 +201,15 @@ extension CapacitorWechat {
     @discardableResult
     func handleOpenURL(_ url: URL) -> Bool {
         WXApi.handleOpen(url, delegate: self)
+    }
+
+    @discardableResult
+    func handleUniversalLink(_ url: URL) -> Bool {
+        // Capacitor posts only the URL on .capacitorOpenUniversalLink; rebuild the
+        // NSUserActivity WeChat's SDK expects.
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = url
+        return WXApi.handleOpenUniversalLink(activity, delegate: self)
     }
 
     @discardableResult

--- a/ios/Sources/CapacitorWechatPlugin/CapacitorWechatPlugin.swift
+++ b/ios/Sources/CapacitorWechatPlugin/CapacitorWechatPlugin.swift
@@ -24,8 +24,8 @@ public class CapacitorWechatPlugin: CAPPlugin, CAPBridgedPlugin {
         NotificationCenter.default.addObserver(self, selector: #selector(handleOpenURL(_:)), name: .capacitorOpenURL, object: nil)
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(handleContinueUserActivity(_:)),
-            name: Notification.Name("capacitorContinueUserActivity"),
+            selector: #selector(handleOpenUniversalLink(_:)),
+            name: .capacitorOpenUniversalLink,
             object: nil
         )
 
@@ -225,11 +225,11 @@ public class CapacitorWechatPlugin: CAPPlugin, CAPBridgedPlugin {
         _ = implementation.handleOpenURL(url)
     }
 
-    @objc private func handleContinueUserActivity(_ notification: Notification) {
+    @objc private func handleOpenUniversalLink(_ notification: Notification) {
         guard let object = notification.object as? [String: Any],
-              let activity = object["userActivity"] as? NSUserActivity else {
+              let url = object["url"] as? URL else {
             return
         }
-        _ = implementation.handleUniversalLink(activity)
+        _ = implementation.handleUniversalLink(url)
     }
 }


### PR DESCRIPTION
## What
- Fix iOS WeChat `auth()` rejecting with `User cancelled the WeChat operation.` and never returning `code` after a successful WeChat authorization.

## Why
- Fixes https://github.com/Cap-go/capacitor-wechat/issues/39
- The plugin listened for a non-existent `capacitorContinueUserActivity` notification and expected an `NSUserActivity` payload. Capacitor posts `.capacitorOpenUniversalLink` with `{ url }`, so Universal Link returns from WeChat never reached `WXApi.handleOpenUniversalLink`.
- `sendAuthReq(_:viewController:)` is meant for devices without WeChat and can emit a spurious user-cancel while opening WeChat when the app is installed.

## How
- Subscribe to `.capacitorOpenUniversalLink` and rebuild an `NSUserActivity` from the posted URL before calling the WeChat SDK.
- When WeChat is installed, send auth with `WXApi.send(_:)` instead of `sendAuthReq(_:viewController:)`.

## Testing
- `bun run verify:web`
- `bun run eslint` / prettier via fmt (SwiftLint failed locally on SourceKit load, unrelated to this change)

## Not Tested
- Physical device WeChat login on iOS 16/18 (needs WeChat app + registered Universal Link)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-wechat/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788691280&installation_model_id=430928&pr_number=42&repository=Cap-go%2Fcapacitor-wechat&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-wechat%2Fpull%2F42&signature=44d3e54b02ba19b6399fe2a73544c9ecf0cf466676c8ff2e08c0836029d3d538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-wechat/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

